### PR TITLE
Align teleop output with ackermann mux

### DIFF
--- a/workspaces/f1tenth_ws/src/ackermann_mux/config/ackermann_mux_topics.yaml
+++ b/workspaces/f1tenth_ws/src/ackermann_mux/config/ackermann_mux_topics.yaml
@@ -1,7 +1,7 @@
 # Input topics handled/muxed.
 # For each topic:
 # - name    : name identifier to select the topic (*sub-namespace, see below)
-# - topic   : input topic of geometry_msgs::Twist type
+# - topic   : input topic of ackermann_msgs/AckermannDriveStamped type
 # - timeout : timeout in seconds to start discarding old messages, and use 0.0 speed instead
 # - priority: priority in the range [0, 255]; the higher the more priority over other topics
 

--- a/workspaces/f1tenth_ws/src/f1tenth_teleop/launch/teleop_ackermann.launch.py
+++ b/workspaces/f1tenth_ws/src/f1tenth_teleop/launch/teleop_ackermann.launch.py
@@ -33,7 +33,9 @@ def generate_launch_description():
                 'max_steering_angle': 0.42,
                 'speed_limit': 1.0,
                 'twist_topic': '/cmd_vel',
-                'ackermann_topic': '/ackermann_cmd',
+                # Publish to the topic expected by ackermann_mux
+                # so the multiplexer can forward commands to the VESC
+                'ackermann_topic': '/joy_vel',
                 'frame_id': 'base_link',
                 'timeout': 0.5,
                 'curv_denom_min': 0.15


### PR DESCRIPTION
## Summary
- publish joystick Ackermann commands to `joy_vel`
- clarify `ackermann_mux_topics.yaml` expects AckermannDriveStamped inputs

## Testing
- `python -m py_compile workspaces/f1tenth_ws/src/f1tenth_teleop/launch/teleop_ackermann.launch.py`
- `colcon test --packages-select f1tenth_teleop ackermann_mux` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `pip install pyyaml` *(fails: tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc21ee0cc83299b86d6b7d47c9c2a